### PR TITLE
add github URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,5 +17,13 @@
   "directories": {
     "example": "example"
   },
-  "description": "A simple module for getting data events from a Korg Nano Kontrol."
+  "description": "A simple module for getting data events from a Korg Nano Kontrol.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/davidguttman/korg-nano.git"
+  },
+  "bugs": {
+    "url": "https://github.com/davidguttman/korg-nano/issues"
+  },
+  "homepage": "https://github.com/davidguttman/korg-nano"
 }


### PR DESCRIPTION
thank you for useful library. I'm using korg-nano to controll Philips Hue in my home.
## added URLs in package.json

npmjs.org uses them to show repository info.
