### PR TITLE
modify MIDI device name for Intel Edison (Yocto Linux)

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ Korg.prototype.createInput = function() {
   var portCount = input.getPortCount()
   for (var i = 0; i <= portCount; i++) {
     var name = input.getPortName(i)
-    if (name.match(/nanoKONTROL SLIDER\/KNOB/)) {
+    if (name.match(/nanoKONTROL/)) {
       input.openPort(i)
       break
     }


### PR DESCRIPTION
Hi
I'm using korg nano KONTROL with Intel Edison, to controll philips-hue lights in my room.

On Edison, the device name becomes `nanoKONTROL 24:0` so I midified `createInput` method.
